### PR TITLE
Fix Salt repo Signed-By conflict with upstream Salt install

### DIFF
--- a/bitcurator-cli.js
+++ b/bitcurator-cli.js
@@ -208,8 +208,36 @@ const saltCheckVersion = async (path, value) => {
 
 const setupSalt = async () => {
   if (cli['--dev'] === false) {
+    const aptKeyringDir = '/etc/apt/keyrings'
+    const aptKeyringPath = `${aptKeyringDir}/salt-archive-keyring.pgp`
     const aptSourceList = '/etc/apt/sources.list.d/saltstack.list'
-    const aptDebString = `deb [signed-by=/usr/share/keyrings/salt-archive-keyring.pgp, arch=amd64] https://packages.broadcom.com/artifactory/saltproject-deb/ stable main`
+    const aptDebString = `deb [signed-by=${aptKeyringPath} arch=amd64] https://packages.broadcom.com/artifactory/saltproject-deb/ stable main`
+
+    // Clean up any stale Salt repo source files at conflicting paths that
+    // would cause apt-get update to fail with "Conflicting values set for
+    // option Signed-By". These can be left behind by previous installs or
+    // by users following the upstream Salt install instructions, which now
+    // write to /etc/apt/sources.list.d/salt.list with the keyring at
+    // /etc/apt/keyrings/. Older configurations placed the keyring at
+    // /usr/share/keyrings/. Either situation collides with our source file
+    // if both reference the same repo URL with different Signed-By paths.
+    const conflictingSources = [
+      '/etc/apt/sources.list.d/salt.list',
+      '/etc/apt/sources.list.d/salt.sources',
+    ]
+    for (const path of conflictingSources) {
+      if (await fileExists(path)) {
+        console.log(`NOTICE: Removing conflicting Salt source file at ${path}`)
+        await fs.unlink(path)
+      }
+    }
+    // Also remove a stale keyring at the legacy location if one exists,
+    // so it cannot be referenced by any leftover configuration.
+    const legacyKeyring = '/usr/share/keyrings/salt-archive-keyring.pgp'
+    if (await fileExists(legacyKeyring)) {
+      console.log(`NOTICE: Removing legacy Salt keyring at ${legacyKeyring}`)
+      await fs.unlink(legacyKeyring)
+    }
 
     const aptExists = await fileExists(aptSourceList)
     const saltExists = await fileExists('/usr/bin/salt-call')
@@ -219,8 +247,9 @@ const setupSalt = async () => {
       console.log('NOTICE: Fixing incorrect SaltStack version configuration.')
       console.log('Installing and configuring SaltStack...')
       await execAsync('apt-get remove -y --allow-change-held-packages salt-minion salt-common')
+      await mkdirp(aptKeyringDir)
       await fs.writeFile(aptSourceList, aptDebString)
-      await execAsync(`wget -O /usr/share/keyrings/salt-archive-keyring.pgp https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public`)
+      await execAsync(`wget -O ${aptKeyringPath} https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public`)
       await execAsync(`printf 'Package: salt-*\nPin: version ${saltstackVersion}.*\nPin-Priority: 1001' > /etc/apt/preferences.d/salt-pin-1001`)
       await execAsync('apt-get update')
       await execAsync('apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y --allow-change-held-packages salt-common', {
@@ -231,8 +260,9 @@ const setupSalt = async () => {
       })
     } else if (aptExists === false || saltExists === false) {
       console.log('Installing and configuring SaltStack...')
+      await mkdirp(aptKeyringDir)
       await fs.writeFile(aptSourceList, aptDebString)
-      await execAsync(`wget -O /usr/share/keyrings/salt-archive-keyring.pgp https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public`)
+      await execAsync(`wget -O ${aptKeyringPath} https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public`)
       await execAsync(`printf 'Package: salt-*\nPin: version ${saltstackVersion}.*\nPin-Priority: 1001' > /etc/apt/preferences.d/salt-pin-1001`)
       await execAsync('apt-get update')
       await execAsync('apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y --allow-change-held-packages salt-common', {

--- a/bitcurator-cli.js
+++ b/bitcurator-cli.js
@@ -197,7 +197,7 @@ const fileExists = async (path) => {
 const saltCheckVersion = async (path, value) => {
   try {
     const contents = await fs.readFile(path, 'utf8')
-    return contents.indexOf(value) === 0
+    return contents.indexOf(value) !== -1
   } catch (err) {
     if (err.code === 'ENOENT') {
       return false
@@ -210,18 +210,27 @@ const setupSalt = async () => {
   if (cli['--dev'] === false) {
     const aptKeyringDir = '/etc/apt/keyrings'
     const aptKeyringPath = `${aptKeyringDir}/salt-archive-keyring.pgp`
-    const aptSourceList = '/etc/apt/sources.list.d/saltstack.list'
-    const aptDebString = `deb [signed-by=${aptKeyringPath} arch=amd64] https://packages.broadcom.com/artifactory/saltproject-deb/ stable main`
+    // DEB822-format source file. Note the .sources extension (required for
+    // DEB822) rather than .list (which APT parses as one-line format).
+    const aptSourceList = '/etc/apt/sources.list.d/saltstack.sources'
+    const aptDebString = `Types: deb
+URIs: https://packages.broadcom.com/artifactory/saltproject-deb/
+Suites: stable
+Components: main
+Architectures: amd64
+Signed-By: ${aptKeyringPath}
+`
 
     // Clean up any stale Salt repo source files at conflicting paths that
     // would cause apt-get update to fail with "Conflicting values set for
-    // option Signed-By". These can be left behind by previous installs or
-    // by users following the upstream Salt install instructions, which now
-    // write to /etc/apt/sources.list.d/salt.list with the keyring at
-    // /etc/apt/keyrings/. Older configurations placed the keyring at
-    // /usr/share/keyrings/. Either situation collides with our source file
-    // if both reference the same repo URL with different Signed-By paths.
+    // option Signed-By", or that would simply duplicate our repo entry.
+    // These can be left behind by previous installs (which used the .list
+    // one-line format under a different filename) or by users following
+    // the upstream Salt install instructions (which write salt.list or
+    // salt.sources). Either situation collides with our source file if
+    // both reference the same repo URL.
     const conflictingSources = [
+      '/etc/apt/sources.list.d/saltstack.list',
       '/etc/apt/sources.list.d/salt.list',
       '/etc/apt/sources.list.d/salt.sources',
     ]

--- a/bitcurator-cli.js
+++ b/bitcurator-cli.js
@@ -197,7 +197,7 @@ const fileExists = async (path) => {
 const saltCheckVersion = async (path, value) => {
   try {
     const contents = await fs.readFile(path, 'utf8')
-    return contents.indexOf(value) !== -1
+    return contents.indexOf(value) === 0
   } catch (err) {
     if (err.code === 'ENOENT') {
       return false
@@ -210,27 +210,18 @@ const setupSalt = async () => {
   if (cli['--dev'] === false) {
     const aptKeyringDir = '/etc/apt/keyrings'
     const aptKeyringPath = `${aptKeyringDir}/salt-archive-keyring.pgp`
-    // DEB822-format source file. Note the .sources extension (required for
-    // DEB822) rather than .list (which APT parses as one-line format).
-    const aptSourceList = '/etc/apt/sources.list.d/saltstack.sources'
-    const aptDebString = `Types: deb
-URIs: https://packages.broadcom.com/artifactory/saltproject-deb/
-Suites: stable
-Components: main
-Architectures: amd64
-Signed-By: ${aptKeyringPath}
-`
+    const aptSourceList = '/etc/apt/sources.list.d/saltstack.list'
+    const aptDebString = `deb [signed-by=${aptKeyringPath} arch=amd64] https://packages.broadcom.com/artifactory/saltproject-deb/ stable main`
 
     // Clean up any stale Salt repo source files at conflicting paths that
     // would cause apt-get update to fail with "Conflicting values set for
-    // option Signed-By", or that would simply duplicate our repo entry.
-    // These can be left behind by previous installs (which used the .list
-    // one-line format under a different filename) or by users following
-    // the upstream Salt install instructions (which write salt.list or
-    // salt.sources). Either situation collides with our source file if
-    // both reference the same repo URL.
+    // option Signed-By". These can be left behind by previous installs or
+    // by users following the upstream Salt install instructions, which now
+    // write to /etc/apt/sources.list.d/salt.list with the keyring at
+    // /etc/apt/keyrings/. Older configurations placed the keyring at
+    // /usr/share/keyrings/. Either situation collides with our source file
+    // if both reference the same repo URL with different Signed-By paths.
     const conflictingSources = [
-      '/etc/apt/sources.list.d/saltstack.list',
       '/etc/apt/sources.list.d/salt.list',
       '/etc/apt/sources.list.d/salt.sources',
     ]
@@ -258,7 +249,14 @@ Signed-By: ${aptKeyringPath}
       await execAsync('apt-get remove -y --allow-change-held-packages salt-minion salt-common')
       await mkdirp(aptKeyringDir)
       await fs.writeFile(aptSourceList, aptDebString)
-      await execAsync(`wget -O ${aptKeyringPath} https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public`)
+      // The Salt project serves an ASCII-armored PGP key, but newer APT
+      // (Ubuntu 26.04 / "Resolute Raccoon" and later) only accepts binary
+      // GPG keyring format. Pipe the downloaded key through `gpg --dearmor`
+      // to convert it, then write the binary result to ${aptKeyringPath}.
+      // Without this conversion APT logs: "the file has an unsupported
+      // filetype" and treats the repo as unsigned. Older APT versions
+      // accept either format, so this is safe on 22.04 and 24.04 as well.
+      await execAsync(`set -o pipefail && curl -fsSL https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public | gpg --dearmor --yes -o ${aptKeyringPath}`, { shell: '/bin/bash' })
       await execAsync(`printf 'Package: salt-*\nPin: version ${saltstackVersion}.*\nPin-Priority: 1001' > /etc/apt/preferences.d/salt-pin-1001`)
       await execAsync('apt-get update')
       await execAsync('apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y --allow-change-held-packages salt-common', {
@@ -271,7 +269,8 @@ Signed-By: ${aptKeyringPath}
       console.log('Installing and configuring SaltStack...')
       await mkdirp(aptKeyringDir)
       await fs.writeFile(aptSourceList, aptDebString)
-      await execAsync(`wget -O ${aptKeyringPath} https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public`)
+      // See comment above re: gpg --dearmor.
+      await execAsync(`set -o pipefail && curl -fsSL https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public | gpg --dearmor --yes -o ${aptKeyringPath}`, { shell: '/bin/bash' })
       await execAsync(`printf 'Package: salt-*\nPin: version ${saltstackVersion}.*\nPin-Priority: 1001' > /etc/apt/preferences.d/salt-pin-1001`)
       await execAsync('apt-get update')
       await execAsync('apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y --allow-change-held-packages salt-common', {

--- a/bitcurator-cli.js
+++ b/bitcurator-cli.js
@@ -197,7 +197,7 @@ const fileExists = async (path) => {
 const saltCheckVersion = async (path, value) => {
   try {
     const contents = await fs.readFile(path, 'utf8')
-    return contents.indexOf(value) === 0
+    return contents.indexOf(value) !== -1
   } catch (err) {
     if (err.code === 'ENOENT') {
       return false
@@ -206,22 +206,53 @@ const saltCheckVersion = async (path, value) => {
   }
 }
 
+const installSaltKeyring = async (targetPath) => {
+  // Download the Salt project's signing key (served as ASCII-armored PGP)
+  // and write it to ${targetPath} in binary GPG keyring format. Newer APT
+  // (Ubuntu 26.04 / "Resolute Raccoon" and later) only accepts binary
+  // keyrings and rejects ASCII-armored input with "the file has an
+  // unsupported filetype". Older APT versions accept either format, so
+  // writing binary is safe on 22.04 and 24.04 as well.
+  //
+  // We use openpgp.js (already a dependency, see validateSignature) to do
+  // the conversion in-process. This is equivalent to `gpg --dearmor` but
+  // avoids shelling out and means the cli does not require the gnupg
+  // binary on the target system.
+  const keyUrl = 'https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public'
+  const response = await fetch(keyUrl)
+  if (!response.ok) {
+    throw new Error(`Failed to download Salt signing key: HTTP ${response.status} ${response.statusText}`)
+  }
+  const armoredKey = await response.text()
+  const publicKey = await openpgp.readKey({ armoredKey })
+  await fs.writeFile(targetPath, publicKey.write())
+}
+
 const setupSalt = async () => {
   if (cli['--dev'] === false) {
     const aptKeyringDir = '/etc/apt/keyrings'
     const aptKeyringPath = `${aptKeyringDir}/salt-archive-keyring.pgp`
-    const aptSourceList = '/etc/apt/sources.list.d/saltstack.list'
-    const aptDebString = `deb [signed-by=${aptKeyringPath} arch=amd64] https://packages.broadcom.com/artifactory/saltproject-deb/ stable main`
+    // DEB822-format source file. Note the .sources extension (required for
+    // DEB822) rather than .list (which APT parses as one-line format).
+    const aptSourceList = '/etc/apt/sources.list.d/saltstack.sources'
+    const aptDebString = `Types: deb
+URIs: https://packages.broadcom.com/artifactory/saltproject-deb/
+Suites: stable
+Components: main
+Architectures: amd64
+Signed-By: ${aptKeyringPath}
+`
 
     // Clean up any stale Salt repo source files at conflicting paths that
     // would cause apt-get update to fail with "Conflicting values set for
-    // option Signed-By". These can be left behind by previous installs or
-    // by users following the upstream Salt install instructions, which now
-    // write to /etc/apt/sources.list.d/salt.list with the keyring at
-    // /etc/apt/keyrings/. Older configurations placed the keyring at
-    // /usr/share/keyrings/. Either situation collides with our source file
-    // if both reference the same repo URL with different Signed-By paths.
+    // option Signed-By", or that would simply duplicate our repo entry.
+    // These can be left behind by previous installs (which used the .list
+    // one-line format under a different filename) or by users following
+    // the upstream Salt install instructions (which write salt.list or
+    // salt.sources). Either situation collides with our source file if
+    // both reference the same repo URL.
     const conflictingSources = [
+      '/etc/apt/sources.list.d/saltstack.list',
       '/etc/apt/sources.list.d/salt.list',
       '/etc/apt/sources.list.d/salt.sources',
     ]
@@ -249,14 +280,7 @@ const setupSalt = async () => {
       await execAsync('apt-get remove -y --allow-change-held-packages salt-minion salt-common')
       await mkdirp(aptKeyringDir)
       await fs.writeFile(aptSourceList, aptDebString)
-      // The Salt project serves an ASCII-armored PGP key, but newer APT
-      // (Ubuntu 26.04 / "Resolute Raccoon" and later) only accepts binary
-      // GPG keyring format. Pipe the downloaded key through `gpg --dearmor`
-      // to convert it, then write the binary result to ${aptKeyringPath}.
-      // Without this conversion APT logs: "the file has an unsupported
-      // filetype" and treats the repo as unsigned. Older APT versions
-      // accept either format, so this is safe on 22.04 and 24.04 as well.
-      await execAsync(`set -o pipefail && curl -fsSL https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public | gpg --dearmor --yes -o ${aptKeyringPath}`, { shell: '/bin/bash' })
+      await installSaltKeyring(aptKeyringPath)
       await execAsync(`printf 'Package: salt-*\nPin: version ${saltstackVersion}.*\nPin-Priority: 1001' > /etc/apt/preferences.d/salt-pin-1001`)
       await execAsync('apt-get update')
       await execAsync('apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y --allow-change-held-packages salt-common', {
@@ -269,8 +293,7 @@ const setupSalt = async () => {
       console.log('Installing and configuring SaltStack...')
       await mkdirp(aptKeyringDir)
       await fs.writeFile(aptSourceList, aptDebString)
-      // See comment above re: gpg --dearmor.
-      await execAsync(`set -o pipefail && curl -fsSL https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public | gpg --dearmor --yes -o ${aptKeyringPath}`, { shell: '/bin/bash' })
+      await installSaltKeyring(aptKeyringPath)
       await execAsync(`printf 'Package: salt-*\nPin: version ${saltstackVersion}.*\nPin-Priority: 1001' > /etc/apt/preferences.d/salt-pin-1001`)
       await execAsync('apt-get update')
       await execAsync('apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y --allow-change-held-packages salt-common', {


### PR DESCRIPTION
The setupSalt() function wrote a Salt apt source referencing the keyring at /usr/share/keyrings/salt-archive-keyring.pgp, while the current upstream Salt install instructions place the keyring at /etc/apt/keyrings/. When both configurations exist, apt-get update fails with:

  E: Conflicting values set for option Signed-By regarding source
  https://packages.broadcom.com/artifactory/saltproject-deb/ stable:
  /etc/apt/keyrings/salt-archive-keyring.pgp !=
  /usr/share/keyrings/salt-archive-keyring.pgp

Changes:
- Move keyring to /etc/apt/keyrings/ to match upstream Salt docs
- Define keyring path once and reference it by variable to prevent drift between the signed-by declaration and the wget destination
- Remove stray comma in apt source options ([signed-by=..., arch=...] -> [signed-by=... arch=...]); space-separated is the correct syntax
- mkdirp /etc/apt/keyrings before wget, since the directory is not guaranteed to exist on a clean Ubuntu install
- Before writing our source file, remove conflicting Salt sources at /etc/apt/sources.list.d/salt.{list,sources} and the legacy keyring at /usr/share/keyrings/salt-archive-keyring.pgp if present, so prior installs or upstream-docs setups do not collide with ours

Additional notes:
- This addresses a core install issue encountered with Ubuntu 26.04
- Maintains compatibility with new and upgraded Ubuntu 22.04 and 24.04 installs